### PR TITLE
Refactor/lib managers apt manager

### DIFF
--- a/lib/managers/apt-manager.zsh
+++ b/lib/managers/apt-manager.zsh
@@ -1,0 +1,100 @@
+#!/bin/zsh
+# APT manager for zsh-system-update
+
+# Dependency guard for output utilities
+if ! typeset -f zsu_print_status >/dev/null 2>&1; then
+    local module="lib/utils/output.zsh"
+    local plugin_dir="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-system-update"
+    local module_path="${plugin_dir}/${module}"
+    print "ERROR: zsu_print_status not found. Ensure output utilities are loaded." >&2
+    source "${module_path}"
+fi
+
+zsu_apt_update_needed() {
+    local VERBOSE="${1:-false}"
+
+    local apt_lists_dir="/var/lib/apt/lists"
+    local update_threshold=3600  # 1 hour in seconds
+    local current_time=$(date +%s)
+    
+    # Check if apt lists directory exists and has recent files
+    if [[ ! -d "$apt_lists_dir" ]]; then
+        return 0  # Directory doesn't exist, update needed
+    fi
+    
+    # Find the most recent file in apt lists directory
+    local latest_file=$(find "$apt_lists_dir" -name "*Release*" -type f -printf '%T@ %p\n' 2>/dev/null | sort -nr | head -1 | cut -d' ' -f1)
+    
+    if [[ -z "$latest_file" ]]; then
+        return 0  # No Release files found, update needed
+    fi
+    
+    # Convert to integer (remove decimal part)
+    latest_file=${latest_file%.*}
+    local time_diff=$((current_time - latest_file))
+    
+    if [[ $time_diff -gt $update_threshold ]]; then
+        if [[ "$VERBOSE" == true ]]; then
+            zsu_print_status "Last apt update was $((time_diff / 60)) minutes ago, updating..."
+        fi
+        return 0  # Update needed
+    else
+        if [[ "$VERBOSE" == true ]]; then
+            zsu_print_status "Apt lists are recent ($((time_diff / 60)) minutes old), skipping update"
+        fi
+        return 1  # Update not needed
+    fi
+
+}
+
+zsu_update_apt() {
+    local VERBOSE="${1:-false}"
+    local SKIP_APT="${2:-false}"
+    local QUIET="${3:-false}"
+    local FORCE_APT_UPDATE="${4:-false}"
+
+    if [[ "$SKIP_APT" == true ]]; then
+        zsu_print_status "Skipping APT updates"
+        return 0
+    fi
+    
+    # Check if apt is available (for non-Debian systems)
+    if ! command -v apt-get >/dev/null 2>&1; then
+        zsu_print_warning "APT not found, skipping APT updates"
+        return 0
+    fi
+    
+    zsu_print_status "Starting APT updates..."
+    
+    local apt_quiet=""
+    local apt_config=""
+    
+    if [[ "$QUIET" == true ]]; then
+        apt_quiet="-qq"
+    fi
+    
+    # Auto-handle configuration prompts
+    apt_config='-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"'
+    
+    # Only update package lists if needed (unless forced)
+    if [[ "$FORCE_APT_UPDATE" == true ]] || zsu_apt_update_needed $VERBOSE; then
+        run_cmd "sudo apt-get update $apt_quiet" "Updating package lists"
+    else
+        zsu_print_status "Package lists are recent, skipping update"
+    fi
+    
+    # Check if upgrades are available using apt-get (more script-friendly)
+    if apt list --upgradable 2>/dev/null | grep -q "upgradable" 2>/dev/null; then
+        run_cmd "sudo apt-get upgrade --yes --no-install-recommends $apt_config" "Upgrading packages"
+    else
+        zsu_print_status "No packages to upgrade"
+    fi
+    
+    run_cmd "sudo apt-get autoremove --yes --purge" "Removing unnecessary packages"
+    run_cmd "sudo apt-get autoclean" "Cleaning package cache"
+    
+    zsu_print_success "APT updates completed"
+
+    return 0
+
+}

--- a/tests/test-zsh-system-update.sh
+++ b/tests/test-zsh-system-update.sh
@@ -198,8 +198,16 @@ load_plugin() {
     fi
     
     # Copy plugin to test location
-    mkdir -p "$HOME/.oh-my-zsh/custom/plugins/zsh-system-update"
-    cp "$plugin_source" "$HOME/.oh-my-zsh/custom/plugins/zsh-system-update/"
+    target_dir="${HOME}/.oh-my-zsh/custom/plugins/zsh-system-update"
+    plugin_dir="$(dirname "$plugin_source")"
+    mkdir -p "${target_dir}"
+    cp "$plugin_source" "${target_dir}"
+
+    # Check if the plugin has a modular structure
+    if [[ -d "${plugin_dir}/lib" ]]; then
+        echo -e "${BLUE}ℹ:${NC} Detected modular plugin structure"
+        cp -r "${plugin_dir}/lib" "${target_dir}"
+    fi
     
     export PLUGIN_FILE="$HOME/.oh-my-zsh/custom/plugins/zsh-system-update/zsh-system-update.plugin.zsh"
     

--- a/zsh-system-update.plugin.zsh
+++ b/zsh-system-update.plugin.zsh
@@ -9,15 +9,16 @@ fpath+="${0:A:h}"
 
 zsu_import() {
     local module="$1"
-    local plugin_dir="${0:A:h}"
+    local plugin_dir="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-system-update"
     local module_path="${plugin_dir}/${module}"
 
     if [[ -f "$module_path" ]]; then
         source "$module_path"
+        return 0
     else
         print "ERROR: Cannot load module: $module" >&2
         return 1
-        fi
+    fi
 }
 
 # Import required modules

--- a/zsh-system-update.plugin.zsh
+++ b/zsh-system-update.plugin.zsh
@@ -23,7 +23,7 @@ zsu_import() {
 # Import required modules
 zsu_import "lib/utils/output.zsh"
 # zsu_import "lib/utils/cache.zsh"
-# zsu_import "lib/managers/apt-manager.zsh"
+zsu_import "lib/managers/apt-manager.zsh"
 # zsu_import "lib/managers/conda-manager.zsh"
 # zsu_import "lib/managers/pip-manager.zsh"
 # zsu_import "lib/managers/flatpak-manager.zsh"
@@ -698,7 +698,7 @@ EOF
         fi
         
         # Run updates
-        update_apt
+        zsu_update_apt $VERBOSE $SKIP_APT $QUIET $FORCE_APT_UPDATE
         update_conda  
         update_pip
         update_flatpak


### PR DESCRIPTION
- refactor: modularize APT manager for zsh-system-update
- refactor: enable APT manager module import and update function call in zsh-system-update
- fix: correct plugin directory path in zsu_import function and improve error handling
- fix: enhance plugin loading in test suite to support modular structure and improve directory handling