### PR TITLE
fix: add hook guard to prevent undesired function execution (v0.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2025-08-04
+
+### Fixed
+- **Hook Guard Protection** - Added execution guard to prevent undesired function execution
+  - Prevents recursive or unexpected execution when other commands are run
+  - Uses `ZSU_RUNNING` environment variable to track execution state
+  - Includes proper cleanup with trap handlers for EXIT, INT, and TERM signals
+  - Resolves issue where plugin would unexpectedly run during `conda activate` and similar commands
+
+### Technical Details
+- Hook guard implementation at function entry point (`zsh-system-update.plugin.zsh:34-44`)
+- All existing functionality preserved and tested (33/33 tests pass)
+- Maintains full backward compatibility with all command-line options
+
 ## [0.3.0] - 2025-07-21
 
 ### Changed
@@ -105,7 +119,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implements proper argument parsing with validation
 - Follows oh-my-zsh plugin conventions and structure
 
-[Unreleased]: https://github.com/cnlee1702/zsh-system-update/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/cnlee1702/zsh-system-update/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/cnlee1702/zsh-system-update/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/cnlee1702/zsh-system-update/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/cnlee1702/zsh-system-update/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/cnlee1702/zsh-system-update/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ MIT License - see LICENSE file for details.
 See [CHANGELOG.md](CHANGELOG.md) for detailed version history.
 
 ### Latest Changes
+- **v0.3.1**: Added hook guard protection to prevent undesired function execution
 - **v0.3.0**: Modular architecture refactor, enhanced test suite, improved maintainability
 - **v0.2.0**: Added Flatpak support, enhanced caching, comprehensive package manager support
 - **v0.1.0**: Initial release with APT, Conda, and pip support

--- a/zsh-system-update.plugin.zsh
+++ b/zsh-system-update.plugin.zsh
@@ -31,6 +31,18 @@ zsu_import "lib/managers/flatpak-manager.zsh"
 
 # Main system update function
 zsh-system-update() {
+    # Hook guard to prevent undesired execution
+    if [[ -n "${ZSU_RUNNING:-}" ]]; then
+        return 0
+    fi
+    
+    # Set execution guard
+    local ZSU_RUNNING=1
+    export ZSU_RUNNING
+    
+    # Ensure guard is cleared on exit
+    trap 'unset ZSU_RUNNING' EXIT INT TERM
+    
     # Local variables to avoid global namespace pollution
     local QUIET=false
     local SKIP_APT=false


### PR DESCRIPTION
## Summary
- Fixes issue where `zsh-system-update` would unexpectedly run when executing other commands like `conda activate <env>`
- Implements execution guard using `ZSU_RUNNING` environment variable
- Adds proper cleanup with trap handlers for EXIT, INT, and TERM signals
- Maintains full backward compatibility with all existing functionality

## Changes Made
- Added hook guard at function entry point (`zsh-system-update.plugin.zsh:34-44`)
- Updated CHANGELOG.md to document v0.3.1 release
- Updated README.md with latest version information
- Created v0.3.1 release tag

## Test Results
- All 33 tests pass with hook guard implementation
- No breaking changes to existing functionality
- Verified protection against recursive execution

## Technical Implementation
The hook guard uses an environment variable `ZSU_RUNNING` to track execution state:
1. Checks if function is already running and exits early if true
2. Sets guard variable and exports it for child processes
3. Uses trap to ensure cleanup on function exit, interruption, or termination

🤖 Generated with [Claude Code](https://claude.ai/code)